### PR TITLE
MSTeams PowerShell scripts for Teams

### DIFF
--- a/Add App to Teams and Tenant/Add App to Teams or Tenant  using Graph API.ps1
+++ b/Add App to Teams and Tenant/Add App to Teams or Tenant  using Graph API.ps1
@@ -1,0 +1,96 @@
+param(
+      [Parameter(Mandatory=$true)][System.String]$OwnerPrincipalName,
+      [Parameter(Mandatory=$true)][System.String]$AppName,
+      [Parameter(Mandatory=$true)][System.String]$Tenantid,
+      [Parameter(Mandatory=$true)][System.String]$client_Id,
+      [Parameter(Mandatory=$true)][System.String]$Client_Secret
+      )
+      
+Connect-MicrosoftTeams
+
+#Grant Adminconsent 
+$Grant= 'https://login.microsoftonline.com/common/adminconsent?client_id='
+$admin = '&state=12345&redirect_uri=https://localhost:1234'
+$Grantadmin = $Grant + $client_Id + $admin
+
+start $Grantadmin
+write-host "login with your tenant login detials to proceed further"
+
+$proceed = Read-host "Press 1 for Add app to Team Press 2 for Add app to Tenant"
+if ($proceed -eq '1')
+{
+        write-host "Creating Access_Token"          
+                  $ReqTokenBody = @{
+             Grant_Type    =  "client_credentials"
+            client_Id     = "$client_Id"
+            Client_Secret = "$Client_Secret"
+            Scope         = "https://graph.microsoft.com/.default"
+        } 
+
+        $loginurl = "https://login.microsoftonline.com/" + "$Tenantid" + "/oauth2/v2.0/token"
+        $Token = Invoke-RestMethod -Uri "$loginurl" -Method POST -Body $ReqTokenBody -ContentType "application/x-www-form-urlencoded"
+
+        $Header = @{
+            Authorization = "$($token.token_type) $($token.access_token)"
+        }
+
+
+#add app to team
+
+
+$getappuri = "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps?filter=name%20eq%20'$AppName'"
+$getapp = Invoke-RestMethod -Headers $Header -Uri $ownerurl  -Method get -ContentType 'application/json'
+$Appid = $getapp.id
+
+write-host "Adding App to Team"
+$id = Read-host "Please provide team name"
+$Appbody = '{
+   "teamsApp@odata.bind":"https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/'+$Appid+'"
+}'
+    $AddAppsuri = "https://graph.microsoft.com/v1.0/teams/" +$id+ "/installedApps"
+    $Apps = Invoke-RestMethod -Headers $Header -Uri $AddAppsuri -body $Appbody -Method post -ContentType 'application/json'
+    write-host "app has been installed to " $id
+}
+
+if ($proceed -eq '2')
+{
+        write-host "Creating Access_Token"          
+                  $ReqTokenBody = @{
+             Grant_Type    =  "client_credentials"
+            client_Id     = "$client_Id"
+            Client_Secret = "$Client_Secret"
+            Scope         = "https://graph.microsoft.com/.default"
+        } 
+
+        $loginurl = "https://login.microsoftonline.com/" + "$Tenantid" + "/oauth2/v2.0/token"
+        $Token = Invoke-RestMethod -Uri "$loginurl" -Method POST -Body $ReqTokenBody -ContentType "application/x-www-form-urlencoded"
+
+        $Header = @{
+            Authorization = "$($token.token_type) $($token.access_token)"
+        }
+
+        $Teams = get-team 
+foreach ($team in $Teams) 
+    {
+
+        $groupid = $team.Groupid
+        $displayname = $team.DisplayName
+          
+            #add app to team
+
+        $getappuri = "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps?filter=name%20eq%20'$AppName'"
+        $getapp = Invoke-RestMethod -Headers $Header -Uri $ownerurl  -Method get -ContentType 'application/json'
+        $Appid = $getapp.id
+
+write-host "Adding App to Team"
+$Appbody = '{
+   "teamsApp@odata.bind":"https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/'+$Appid+'"
+}'
+    $AddAppsuri = "https://graph.microsoft.com/v1.0/teams/" +$groupid+ "/installedApps"
+    $Apps = Invoke-RestMethod -Headers $Header -Uri $AddAppsuri -body $Appbody -Method post -ContentType 'application/json'
+    write-host $displayname "has been installed" 
+
+}
+            
+    
+    }}

--- a/Add App to Teams and Tenant/README.md
+++ b/Add App to Teams and Tenant/README.md
@@ -1,0 +1,121 @@
+# Add App to Teams or Tenant
+
+# Description
+
+  Script is to add TeamsApp to Teams or tenant by providing the parameters OwnerPrincipalName,AppName and selecting the input 
+  
+# Prerequisites
+  
+ [Create new Azure App.](https://docs.microsoft.com/en-us/graph/auth-register-app-v2)
+
+ [How to apply permissions](https://docs.microsoft.com/en-us/graph/notifications-integration-app-registration) to your newly created App.
+ 
+ Please collect client id, client secret from created Azure app and tenant id from Azure portal
+  
+ ##### Required Permissions
+ 
+|Permission type	|Permissions (from least to most privileged)|
+|----|----|
+|Application	|TeamsAppInstallation.ReadWriteForTeam.All, Group.ReadWrite.All, Directory.ReadWrite.All|
+  
+ # Example
+  
+   Input 1 for add App to Team, enter the Team name to add App 
+  
+   Input 2 for add App to Tenant, script will fectch the Teams in tenant and adds given app to Teams
+   
+ # Parameters
+ 
+`-TeamId`
+
+Team identifier in Microsoft Teams
+
+Type:	String
+***
+Aliases:	GroupId
+***
+Position:	Named
+***
+Default value:	None
+***
+Accept pipeline input:	True
+***
+Accept wildcard characters:	False
+
+`-AppId`
+
+Teams App identifier in Microsoft Teams
+
+Type:	String
+***
+Position:	Named
+***
+Default value:	None
+***
+Accept pipeline input:	True
+***
+Accept wildcard characters:	False
+
+`-TenantId`
+
+Specifies the unique ID of the tenant on which to perform the operation. The default value is the tenant of the current user. This parameter applies only to partner users.
+
+Type:	Guid
+***
+Position:	Named
+***
+Default value:	None
+***
+Accept pipeline input:	True
+***
+Accept wildcard characters:	False
+  
+# Inputs
+  
+  Tenant_Id, Client_Id, Client_Secret
+  
+  [Find your tenant ID](https://docs.microsoft.com/en-us/onedrive/find-your-office-365-tenant-id#:~:text=In%20this%20article,your%20organization%20name%20or%20domain.)
+  
+  OwnerPrincipalName
+  
+  AppName
+  
+  TeamName
+    
+# Procedure to run the script
+ 
+   To excute `Add App to Teams and Tenant` download/copy and paste the script into powershell
+        
+   Provide the input parameters OwnerPrincipalName, AppName, Client_Id, Client_Secret, Tenantid and hit enter to proceed further on the script
+   
+   Please provide the global administrator credentials or Teams administrator credentials to `Connect-microsoftteams`
+        
+   Now script will redirect to web page for login
+        
+   ![Signin](https://github.com/Geetha63/MS-Teams-Scripts/blob/master/Images/Siginin.png)
+        
+   Provide admin credentials i.e user ID and password 
+        
+   Press enter to continue
+   
+   Once you are login it will shows the below image for grant permissions for the app to perform the operations
+
+ ![GrantPermission](https://github.com/Geetha63/MS-Teams-Scripts/blob/master/Images/GrantPermissions.png)	
+ 
+ ![GrantPermission](https://github.com/Geetha63/MS-Teams-Scripts/blob/master/Images/GrantPermissions2.png)
+ 
+ **Click Accept**
+
+ If you have provided the correct credentials it will give success status `admin_consent = True`
+ 
+ Please choose the option 1 for add app to Team and enter the Team name 
+ 
+ 2 for add app to Tenant
+
+ ### Example 
+ 
+    To install OneNote, please provide app displayname: OneNote for parameter $AppName, OneNote will be installed after successful running of the script 
+    
+#### Expected Output
+OneNote has been installed  
+

--- a/Add App to Teams/Add-TeamsAppInstallation.ps1
+++ b/Add App to Teams/Add-TeamsAppInstallation.ps1
@@ -1,10 +1,34 @@
-﻿$logfile = "C:\TeamsAppInstallationlog_$(get-date -format `"yyyyMMdd_hhmmsstt`").txt"
+# This script will add App to team using Teams powershell module cmdlets
+param(
+[Parameter(Mandatory=$true)][System.String]$AppName,
+[Parameter(Mandatory=$true)][System.String]$TeamId
+)
+$logfile = ".\TeamsAppInstallationlog_$(get-date -format `"yyyyMMdd_hhmmsstt`").txt"
 $start = [system.datetime]::Now
 
-Connect-MicrosoftTeams
-$AppName=Read-Host "Please enter AppName"
+If(Get-Module -ListAvailable -Name MicrosoftTeams) 
+ { 
+ Write-Host "MicrosoftTeams Already Installed" 
+ } 
+ else { 
+ try {
+     Install-Module -Name MicrosoftTeams
+     Write-Host "Installed MicrosoftTeams"
+     }
+ catch{
+        $_.Exception.Message | out-file -Filepath $logfile -append
+     }
+  }
+ 
+     try{
+        Connect-MicrosoftTeams
+        }
+     catch{
+            $_.Exception.Message | out-file -Filepath $logfile -append
+         }
+
 try{
-$App=Get-TeamsApp -DisplayName "$AppName"
+$App = Get-TeamsApp -DisplayName "$AppName"
 $APP
 }
 catch{
@@ -12,7 +36,7 @@ $_.Exception.Message | out-file -Filepath $logfile -append
 }
 
 $AppId =$App.Id
-$TeamId= Read-Host "Please enter TeamId"
+
 try{
 Add-TeamsAppInstallation -AppId $AppId -TeamId $TeamId
 }

--- a/Add App to Teams/Add-TeamsAppInstallation.ps1
+++ b/Add App to Teams/Add-TeamsAppInstallation.ps1
@@ -1,0 +1,24 @@
+﻿$logfile = "C:\TeamsAppInstallationlog_$(get-date -format `"yyyyMMdd_hhmmsstt`").txt"
+$start = [system.datetime]::Now
+
+Connect-MicrosoftTeams
+$AppName=Read-Host "Please enter AppName"
+try{
+$App=Get-TeamsApp -DisplayName "$AppName"
+$APP
+}
+catch{
+$_.Exception.Message | out-file -Filepath $logfile -append
+}
+
+$AppId =$App.Id
+$TeamId= Read-Host "Please enter TeamId"
+try{
+Add-TeamsAppInstallation -AppId $AppId -TeamId $TeamId
+}
+catch{
+$_.Exception.Message | out-file -Filepath $logfile -append
+}
+$end = [system.datetime]::Now
+$resultTime = $end - $start
+Write-Host "Execution took : $($resultTime.TotalSeconds) seconds." -ForegroundColor Cyan

--- a/Add App to Teams/README.md
+++ b/Add App to Teams/README.md
@@ -1,8 +1,8 @@
-# Add App to Teams or Tenant
+# Add App to Team
 
 # Description
 
-Script is to add TeamsApp to Teams by providing the parameters TeamId and AppName 
+This PowerShell script is to add a Teams App to Microsoft Teams by providing Teamid and AppName
   
 # Prerequisites
 

--- a/Add App to Teams/README.md
+++ b/Add App to Teams/README.md
@@ -1,0 +1,66 @@
+# Add App to Teams or Tenant
+
+# Description
+
+Script is to add TeamsApp to Teams by providing the parameters TeamId and AppName 
+  
+# Prerequisites
+
+Microsoft Teams PowerShell public preview
+
+[Reference link](https://docs.microsoft.com/en-us/microsoftteams/teams-powershell-install)
+  
+# Parameters
+ 
+`-TeamId`
+
+Team identifier in Microsoft Teams
+
+Type:	String
+***
+Aliases:	GroupId
+***
+Position:	Named
+***
+Default value:	None
+***
+Accept pipeline input:	True
+***
+Accept wildcard characters:	False
+
+`-AppId`
+
+Teams App identifier in Microsoft Teams
+
+Type:	String
+***
+Position:	Named
+***
+Default value:	None
+***
+Accept pipeline input:	True
+***
+Accept wildcard characters:	False
+  
+# Inputs
+ 
+  AppName
+  
+  TeamId
+    
+# Procedure to run the script
+ 
+   To excute `Add App to Teams` download/copy and paste the script into powershell
+   
+   Please provide the global administrator credentials or Teams administrator credentials to connect MicrosoftTeams module
+        
+   Provide the input parameters AppName,TeamId and hit enter to proceed further on the script
+       
+ ### Example 
+ 
+ To install OneNote app, please provide app displayname: OneNote for parameter $AppName, OneNote will be installed after successful running of the script 
+    
+#### Expected Output
+OneNote has been installed  
+
+A log file will be generated with exceptions, errors along with script execution time

--- a/Create New-CsTeamsMessagingPolicy/New-CsTeamsMessagingPolicy.ps1
+++ b/Create New-CsTeamsMessagingPolicy/New-CsTeamsMessagingPolicy.ps1
@@ -1,0 +1,18 @@
+$logfile = "C:\CreateNew-CsTeamsMessagingPolicylog_$(get-date -format `"yyyyMMdd_hhmmsstt`").txt"
+$start = [system.datetime]::Now
+
+Import-Module SkypeOnlineConnector
+$sfbSession = New-CsOnlineSession 
+Import-PSSession $sfbSession -AllowClobber
+
+$PolicyName = Read-Host "Please provide PolicyName"
+ try{
+New-CsTeamsMessagingPolicy -Identity "$PolicyName" -AllowUserChat $false
+}
+catch{
+$_.Exception.Message | out-file -Filepath $logfile -append
+}
+Write-Host "AllowUserChat is set to False"
+$end = [system.datetime]::Now
+$resultTime = $end - $start
+Write-Host "Execution took : $($resultTime.TotalSeconds) seconds." -ForegroundColor Cyan

--- a/Create New-CsTeamsMessagingPolicy/New-CsTeamsMessagingPolicy.ps1
+++ b/Create New-CsTeamsMessagingPolicy/New-CsTeamsMessagingPolicy.ps1
@@ -1,11 +1,16 @@
-$logfile = "C:\CreateNew-CsTeamsMessagingPolicylog_$(get-date -format `"yyyyMMdd_hhmmsstt`").txt"
+# This script will create Microsoft Teams messaging policy (Restricting peer - peer chat) using PowerShell cmdlets.
+
+param(
+      [Parameter(Mandatory=$true)][System.String]$PolicyName
+      )
+
+$logfile = ".\CreateNew-CsTeamsMessagingPolicylog_$(get-date -format `"yyyyMMdd_hhmmsstt`").txt"
 $start = [system.datetime]::Now
 
 Import-Module SkypeOnlineConnector
 $sfbSession = New-CsOnlineSession 
 Import-PSSession $sfbSession -AllowClobber
 
-$PolicyName = Read-Host "Please provide PolicyName"
  try{
 New-CsTeamsMessagingPolicy -Identity "$PolicyName" -AllowUserChat $false
 }

--- a/Create New-CsTeamsMessagingPolicy/README.md
+++ b/Create New-CsTeamsMessagingPolicy/README.md
@@ -1,0 +1,42 @@
+# Create New-CsTeamsMessagingPolicy
+
+# Description
+The New-CsTeamsMessagingPolicy script enables administrators to control user TeamsMessagingPolicy, determines whether a user is allowed to chat. Set this to TRUE to allow a user to chat across the private chat. Set this to FALSE to prohibit private chat
+
+# Example
+    New-CsTeamsMessagingPolicy -Identity "StudentMessagingPolicy" -AllowUserChat $false
+
+# Parameters
+`-AllowUserChat`
+
+Determines whether a user is allowed to chat. Set this to TRUE to allow a user to chat across the private chat. Set this to FALSE to prohibit private chat
+
+Type:	                               Boolean 
+ * * *
+Position:	                           Named
+- - -
+Default value:                         None
+- - -
+Accept pipeline input:	               False
+* * *
+Accept wildcard characters:	           False
+* * *
+
+# Prerequisite
+1)	Install [SFB online connector](https://www.microsoft.com/en-us/download/details.aspx?id=39366)
+
+# Inputs
+Provide the parameter
+`policyname` Ex:StudentMessagingPolicy
+
+# How to run the script
+
+1. As an Administrator, type PowerShell in the start menu. Right-click on Windows PowerShell, then select Run as Administrator.
+Click Yes at the UAC prompt
+
+2)	Run the **`Create New-CsTeamsMessagingPolicy.ps1`**
+
+# Output
+AllowUserChat is set to False
+
+A log file will be generated with exceptions, errors along with script execution time 

--- a/CreateTeamsalongwithAPPs/CreateTeamsAlongWithApps.ps1
+++ b/CreateTeamsalongwithAPPs/CreateTeamsAlongWithApps.ps1
@@ -1,0 +1,126 @@
+
+$logfile = "C:\log_$(get-date -format `"yyyyMMdd_hhmmsstt`").txt"
+$start = [system.datetime]::Now
+
+     $Tenantid = read-host "Please provide tenant id"
+     $client_Id = Read-host "Please provide client id"
+     $Client_Secret = read-host "Please provide client secret"
+     $AppName = read-host "Please provide AppName"
+     $OwnerPrincipalName = read-host "Please provice OwnerPrincipalName"
+     $Groupname = read-host "Please provide Groupname"
+           
+#Grant Adminconsent 
+$Grant= 'https://login.microsoftonline.com/common/adminconsent?client_id='
+$admin = '&state=12345&redirect_uri=https://localhost:1234'
+$Grantadmin = $Grant + $client_Id + $admin
+
+start-process $Grantadmin
+write-host "login with your tenant login detials to proceed further"
+
+$proceed = Read-host " Press Y to continue "
+if ($proceed -eq 'Y')
+{
+    write-host "Creating Access_Token"          
+              $ReqTokenBody = @{
+         Grant_Type    =  "client_credentials"
+        client_Id     = "$client_Id"
+        Client_Secret = "$Client_Secret"
+        Scope         = "https://graph.microsoft.com/.default"
+    } 
+
+    $loginurl = "https://login.microsoftonline.com/" + "$Tenantid" + "/oauth2/v2.0/token"
+    try{
+    $Token = Invoke-RestMethod -Uri "$loginurl" -Method POST -Body $ReqTokenBody -ContentType "application/x-www-form-urlencoded"
+      }
+      Catch {
+     $_.Exception | Out-File $logfile -Append
+      }
+    $Header = @{
+        Authorization = "$($token.token_type) $($token.access_token)"
+    }
+
+#create Group with owner
+write-host "Creating Group with owner"
+$ownerurl = "https://graph.microsoft.com/v1.0/users/" + "$OwnerPrincipalName"
+try{
+$owner = Invoke-RestMethod -Headers $Header -Uri $ownerurl  -Method get -ContentType 'application/json'
+}
+Catch {
+    $_.Exception | Out-File $logfile -Append
+   }
+$ownerid = $owner.id
+$groupbody = '{
+  "description": "Group with designated owner and members",
+  "displayName": "Operations group",
+  "groupTypes": [
+    "Unified"
+  ],
+  "mailEnabled": true,
+  "mailNickname": "operations2019",
+  "securityEnabled": false,
+  "owners@odata.bind": [
+    "https://graph.microsoft.com/v1.0/users/'+$ownerid+'"
+  ]
+}'
+
+
+    $groupurl = "https://graph.microsoft.com/v1.0/groups" 
+    try{
+    $Group = Invoke-RestMethod -Headers $Header -Uri $groupurl -body $groupbody -Method post -ContentType 'application/json'
+    }
+    Catch {
+    $_.Exception | Out-File $logfile -Append
+   }
+    $id = $group.id
+
+#convert that Group to team
+write-host "Creating Team"
+$teambody = '{  
+  "memberSettings": {
+    "allowCreateUpdateChannels": true
+  },
+  "messagingSettings": {
+    "allowUserEditMessages": true,
+    "allowUserDeleteMessages": true
+  },
+  "funSettings": {
+    "allowGiphy": true,
+    "giphyContentRating": "strict"
+  }
+}'
+    $teamuri = "https://graph.microsoft.com/v1.0/groups/" +$id+ "/team" 
+    try{
+    $Team = Invoke-RestMethod -Headers $Header -Uri $teamuri -body $teambody -Method put -ContentType 'application/json'
+    }
+    Catch {
+    $_.Exception | Out-File $logfile -Append
+    }
+
+#add app to team
+
+$getappuri = "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps?filter=name%20eq%20'$AppName'"
+try{
+$getapp = Invoke-RestMethod -Headers $Header -Uri $getappuri  -Method get -ContentType 'application/json'
+}
+Catch {
+    $_.Exception | Out-File $logfile -Append
+   }
+$Appid = $getapp.id
+
+write-host "Adding App to Team"
+$Appbody = '{
+   "teamsApp@odata.bind":"https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/'+$Appid+'"
+}'
+    $AddAppsuri = "https://graph.microsoft.com/v1.0/teams/" +$id+ "/installedApps"
+    try{
+    Invoke-RestMethod -Headers $Header -Uri $AddAppsuri -body $Appbody -Method post -ContentType 'application/json'
+    }
+    Catch {
+    $_.Exception | Out-File $logfile -Append
+   }
+write-host "App has been added to team"
+}
+
+$end = [system.datetime]::Now
+$resultTime = $end - $start
+Write-Host "Execution took : $($resultTime.TotalSeconds) seconds." -ForegroundColor Cyan

--- a/CreateTeamsalongwithAPPs/CreateTeamsAlongWithApps.ps1
+++ b/CreateTeamsalongwithAPPs/CreateTeamsAlongWithApps.ps1
@@ -1,13 +1,16 @@
+# This script will create Team along with apps using graph api calling method.
 
-$logfile = "C:\log_$(get-date -format `"yyyyMMdd_hhmmsstt`").txt"
+param(
+      [Parameter(Mandatory=$true)][System.String]$OwnerPrincipalName,
+      [Parameter(Mandatory=$true)][System.String]$AppName,
+      [Parameter(Mandatory=$true)][System.String]$Groupname,
+      [Parameter(Mandatory=$true)][System.String]$Tenantid,
+      [Parameter(Mandatory=$true)][System.String]$client_Id,
+      [Parameter(Mandatory=$true)][System.String]$Client_Secret
+      )
+      
+$logfile = ".\log_$(get-date -format `"yyyyMMdd_hhmmsstt`").txt"
 $start = [system.datetime]::Now
-
-     $Tenantid = read-host "Please provide tenant id"
-     $client_Id = Read-host "Please provide client id"
-     $Client_Secret = read-host "Please provide client secret"
-     $AppName = read-host "Please provide AppName"
-     $OwnerPrincipalName = read-host "Please provice OwnerPrincipalName"
-     $Groupname = read-host "Please provide Groupname"
            
 #Grant Adminconsent 
 $Grant= 'https://login.microsoftonline.com/common/adminconsent?client_id='

--- a/CreateTeamsalongwithAPPs/README.md
+++ b/CreateTeamsalongwithAPPs/README.md
@@ -1,0 +1,91 @@
+# CreateTeamsalongwithAPPs
+
+# Description
+
+Create MicrosoftTeams along with APP for your tenant
+
+# Prerequisites
+
+[Create a new Azure App](https://docs.microsoft.com/en-us/graph/auth-register-app-v2)
+
+[How to apply permissions](https://docs.microsoft.com/en-us/graph/notifications-integration-app-registration) to your newly created App
+
+Please collect client id, client secret from created Azure app and tenant id from Azure portal
+                
+#### Required Permissions
+
+| Permission type | Permissions (from least to most privileged)|
+|-----------------|--------------------------------------------|
+|Application|Group.Create, Group.ReadWrite.All, Directory.ReadWrite.All|
+
+# Example
+
+Group Name: HR, OwnerPrincipalName: AdeleV@contoso.com, AppName: OneNote
+
+OneNote has been added to HR 
+
+# Parameters
+
+`-GroupId`
+
+Specify a GroupId to convert to a Team. If specified, you cannot provide the other values that are already specified by the existing group, namely: Visibility, Alias, Description, or DisplayName. If, for example, you need to create a Team from an existing Microsoft 365 Group, use the ExternalDirectoryObjectId property value returned by [Get-UnifiedGroup](https://docs.microsoft.com/en-us/powershell/module/exchange/get-unifiedgroup?view=exchange-ps)
+
+Type:	String
+***
+Position:	Named
+***
+Default value:	None
+***
+Accept pipeline input:	True
+***
+Accept wildcard characters:	False
+
+`-AppId`
+
+Teams App identifier in Microsoft Teams
+
+Type:	String
+***
+Position:	Named
+***
+Default value:	None
+***
+Accept pipeline input:	True
+***
+Accept wildcard characters:	False
+
+# Inputs
+
+Groupname, OwnerPrincipalName, AppName, Client_Id, Client_Secret,Tenantid
+
+# Procedure to run the script
+
+   To execute `CreateTeamsalongwithAPPs` download/copy and paste the script into PowerShell
+        
+   Provide the input parameters Groupname, OwnerPrincipalName, AppName, Client_Id, Client_Secret, TenantId and hit enter to proceed further on the script
+        
+   Now the script will redirect to the web page for login
+        
+   ![Signin](https://github.com/Geetha63/MS-Teams-Scripts/blob/master/Images/Siginin.png)
+        
+   Provide Administrator credentials i.e user ID and password 
+        
+   Press enter to continue
+   
+   Once you are login it will show the below image for Grant permissions for the app to perform the operations
+
+ ![GrantPermission](https://github.com/Geetha63/MS-Teams-Scripts/blob/master/Images/GrantPermissions.png)
+ 
+ ![GrantPermission](https://github.com/Geetha63/MS-Teams-Scripts/blob/master/Images/GrantPermissions2.png)
+ 
+ **Click Accept**
+
+ If you have provided the correct credentials it will give success status `admin_consent = True`
+ 
+ Now press Y to proceed further in the script
+ 
+# Output
+
+Script will execute and create the Team using provided Group Name, OwnerPrincipalName and APPName
+
+App has been added to the team

--- a/DeleteTeamsWhereTeamMembersdontHaveGivenJobtitles/DeleteTeamsWhereTeamMembersdontHaveGivenJobtitles.ps1
+++ b/DeleteTeamsWhereTeamMembersdontHaveGivenJobtitles/DeleteTeamsWhereTeamMembersdontHaveGivenJobtitles.ps1
@@ -1,0 +1,153 @@
+﻿#this script will Delete the all teams except given job titles match
+#Provide job title phrases separate by , 
+#for best practice run the script quote delete cmdlet
+
+$logfile = "C:\log_$(get-date -format `"yyyyMMdd_hhmmsstt`").txt"
+$start = [system.datetime]::Now
+
+     $Tenantid=read-host "Please provide tenant id"
+     $client_Id=Read-host "Please provide client id"
+     $Client_Secret=read-host "Please provide client secret"
+     $mailsender = read-host "Please provide mailsender"
+     $KeepJobtitles = read-host "Please provide KeepJobtitles"
+
+#Grant Adminconsent 
+$Grant= 'https://login.microsoftonline.com/common/adminconsent?client_id='
+$admin = '&state=12345&redirect_uri=https://localhost:1234'
+$Grantadmin = $Grant + $client_Id + $admin
+
+Start-Process $Grantadmin
+write-host "login with your tenant login detials to proceed further"
+
+$proceed = Read-host " Press Y to continue "
+if ($proceed -eq 'Y')
+{
+    write-host "Creating Access_Token"          
+              $ReqTokenBody = @{
+         Grant_Type    =  "client_credentials"
+        client_Id     = "$client_Id"
+        Client_Secret = "$Client_Secret"
+        Scope         = "https://graph.microsoft.com/.default"
+    }
+
+    $loginurl = "https://login.microsoftonline.com/" + "$Tenantid" + "/oauth2/v2.0/token"
+    try{
+    $Token = Invoke-RestMethod -Uri "$loginurl" -Method POST -Body $ReqTokenBody -ContentType "application/x-www-form-urlencoded"
+      }
+      Catch {
+    $_.Exception | Out-File $logfile -Append
+      }
+    $Header = @{
+        Authorization = "$($token.token_type) $($token.access_token)"
+    }
+    
+   #getting All teams
+   write-host "Getting All teams"
+
+   $getTeams = "https://graph.microsoft.com/beta/groups?filter=resourceProvisioningOptions/Any(x:x eq 'Team')" 
+   try{
+   $Teams = Invoke-RestMethod -Headers $Header -Uri $getTeams -Method get -ContentType 'application/json'
+   }
+   Catch {
+    $_.Exception | Out-File $logfile -Append
+   }
+   $values = $Teams.value
+   $groupid = $values.id
+   $displayname = $values | select displayName
+   
+   #getting members
+   write-host "Getting members for each team"
+   $results = foreach($team in $values)
+   {
+           $id = $team.id
+           $TeamName = $team.displayName
+           write-host "Checking job title of users in $TeamName"
+            
+            $memberuri = "https://graph.microsoft.com/v1.0/groups/"+ "$id" +"/members"
+            try{
+            $members = Invoke-RestMethod -Headers $Header -Uri $memberuri -Method get -ContentType 'application/json'
+            }
+            Catch {
+             $_.Exception | Out-File $logfile -Append
+            }
+            # for each member - check the designation
+            $keepTeam = $false
+                        
+            foreach($member in $members.value)
+            {
+                if( "$KeepJobtitles"  -contains $member.jobTitle)
+                    {
+                        $keepTeam = $true
+                    }
+            }
+            # delete if flag is false
+            if(!$keepTeam)
+             {      
+                    $DeletedTeam = $team | select displayName
+                    $deleteURL = "https://graph.microsoft.com/v1.0/groups/" + "$id" 
+                    try{
+                    #$DeleteTeam = Invoke-RestMethod -Headers $Header -Uri $deleteURL -Method DELETE 
+                    }
+                    Catch {
+                      $_.Exception | Out-File $logfile -Append
+                     }
+                    write-host "$Teamname has been deleted"
+                    
+                    $owneruri = "https://graph.microsoft.com/v1.0/groups/" + "$id" + "/owners"
+                    try{
+                    $Teamowners = Invoke-RestMethod -Headers $Header -Uri $owneruri -Method Get
+                    }
+                    Catch {
+                      $_.Exception | Out-File $logfile -Append
+                     }
+                    $Teamownervalues = $Teamowners.value 
+                    $OwneruserPrincipalName = $Teamownervalues.userPrincipalName
+                    $owners = [string]::Join(", ",$OwneruserPrincipalName) 
+
+                    $file = New-Object psobject
+                    $file | add-member -MemberType NoteProperty -Name DeletedTeam $DeletedTeam.displayName
+                    $file | add-member -MemberType NoteProperty -Name TeamsOwner $owners
+                    $file | export-csv output.csv -NoTypeInformation -Append
+                 write-host "Mail has been sent to $owners"
+                 $mailuri = "https://graph.microsoft.com/v1.0/users/" + "$mailsender" + "/sendMail"
+
+                    $body = '{
+  "message": {
+    "subject": "Your team ' +$Teamname+ ' has been deleted because of complaince reason",
+    "body": {
+      "contentType": "Text",
+      "content": "Your team ' +$Teamname+ ' has been deleted because of complaince reason"
+    },
+    "toRecipients": [
+      {
+        "emailAddress": {
+          "address": "' +$owners+ '"
+        }
+      }
+    ],
+    "ccRecipients": [
+      {
+        "emailAddress": {
+          "address": "' +$mailsender+ '"
+        }
+      }
+    ]
+  },
+  "saveToSentItems": "True"
+}'
+try{
+            $smtp = Invoke-RestMethod -Headers $Header -Uri $mailuri -body $body -Method post -ContentType application/json
+            }
+            Catch {
+    $_.Exception | Out-File $logfile -Append
+   }
+             }
+   }
+   
+ } 
+   
+else{ write-host Re run the script and press Y}
+$end = [system.datetime]::Now
+$resultTime = $end - $start
+Write-Host "Execution took : $($resultTime.TotalSeconds) seconds." -ForegroundColor Cyan
+

--- a/DeleteTeamsWhereTeamMembersdontHaveGivenJobtitles/DeleteTeamsWhereTeamMembersdontHaveGivenJobtitles.ps1
+++ b/DeleteTeamsWhereTeamMembersdontHaveGivenJobtitles/DeleteTeamsWhereTeamMembersdontHaveGivenJobtitles.ps1
@@ -1,15 +1,18 @@
-﻿#this script will Delete the all teams except given job titles match
+﻿#This script will delete all Teams except given job titles match
 #Provide job title phrases separate by , 
-#for best practice run the script quote delete cmdlet
+#For best practice run the script quote delete cmdlet
 
-$logfile = "C:\log_$(get-date -format `"yyyyMMdd_hhmmsstt`").txt"
+#Example :Script will delete HR Team if anyone of Team member job title does not match and the script will send an email to HR Team owner behalf of mailsender(admin@contoso.com)
+
+param(
+      [Parameter(Mandatory=$true)][System.String]$mailsender,
+      [Parameter(Mandatory=$true)][System.String]$KeepJobtitles,
+      [Parameter(Mandatory=$true)][System.String]$Tenantid,
+      [Parameter(Mandatory=$true)][System.String]$client_Id,
+      [Parameter(Mandatory=$true)][System.String]$Client_Secret
+      )
+$logfile = ".\log_$(get-date -format `"yyyyMMdd_hhmmsstt`").txt"
 $start = [system.datetime]::Now
-
-     $Tenantid=read-host "Please provide tenant id"
-     $client_Id=Read-host "Please provide client id"
-     $Client_Secret=read-host "Please provide client secret"
-     $mailsender = read-host "Please provide mailsender"
-     $KeepJobtitles = read-host "Please provide KeepJobtitles"
 
 #Grant Adminconsent 
 $Grant= 'https://login.microsoftonline.com/common/adminconsent?client_id='
@@ -86,7 +89,7 @@ if ($proceed -eq 'Y')
                     $DeletedTeam = $team | select displayName
                     $deleteURL = "https://graph.microsoft.com/v1.0/groups/" + "$id" 
                     try{
-                    #$DeleteTeam = Invoke-RestMethod -Headers $Header -Uri $deleteURL -Method DELETE 
+                    $DeleteTeam = Invoke-RestMethod -Headers $Header -Uri $deleteURL -Method DELETE 
                     }
                     Catch {
                       $_.Exception | Out-File $logfile -Append
@@ -150,4 +153,3 @@ else{ write-host Re run the script and press Y}
 $end = [system.datetime]::Now
 $resultTime = $end - $start
 Write-Host "Execution took : $($resultTime.TotalSeconds) seconds." -ForegroundColor Cyan
-

--- a/DeleteTeamsWhereTeamMembersdontHaveGivenJobtitles/README.md
+++ b/DeleteTeamsWhereTeamMembersdontHaveGivenJobtitles/README.md
@@ -1,0 +1,92 @@
+# DeleteTeamsWhereTeamMembersdontHaveGivenJobtitles
+
+# Description
+
+This script checks each Team member job title, if at least one job title does not match to given job titles, the script will delete those Teams. It will generate the ouput.csv file in the current folder and sent an email to deleted Team owners
+
+This is a Graph API script, to execute the script user needs to create an Azure App and provide the necessary permissions 
+
+# Prerequisites
+
+[Create a new Azure App](https://docs.microsoft.com/en-us/graph/auth-register-app-v2)
+
+[How to apply permissions](https://docs.microsoft.com/en-us/graph/notifications-integration-app-registration) to your newly created App
+
+Please collect client id, client secret from created Azure app and tenant id from Azure portal
+
+### Requried Permissions
+
+|Permission type	          |  Permissions (from least to most privileged)|
+|----------|-------------------|
+|Application|Directory.AccessAsUser.All, Mail.Send|
+
+# Example
+
+Mailsender AdeleV@contoso.com
+
+Keepjobtitles Manager, Hr, Associate 
+
+Script will delete HR Team if anyone of Team member job title does not match and the script will send an email to HR Team owner behalf of mailsender(AdeleV@contoso.com)
+
+# Parameters
+
+ `mailsender`
+ 
+   User Principal Name(for example AdeleV@contoso.com) to send an email to Teams owner of deleted Teams 
+   
+   Type: string 
+
+ `KeepJobtitles`
+ 
+   Designation of the employe(for example Manager)
+   
+   Type: string 
+      
+# Inputs
+   
+   Client_Id
+   
+   Client_Secret
+   
+   TenantId
+   
+   Mail sender
+   
+   KeepJobtitles
+        
+ # Procedure to run the script
+ 
+   To excute `DeleteTeamsWhereTeamMembersdontHaveGivenJobtitles` download/copy and paste the script into PowerShell
+        
+   Provide the input parameters Mailsender, Client_Id, Client_Secret, TenantId, KeepJobtitles and hit enter to proceed further on the script
+        
+   Now the script will redirect to the web page for login
+        
+   ![Signin](https://github.com/Geetha63/MS-Teams-Scripts/blob/master/Images/Siginin.png)
+        
+   Provide admin credentials i.e user ID and password 
+        
+   Press enter to continue
+   
+   Once you are login it will show the below image for grant permissions for the app to perform the operations
+
+ ![GrantPermission](https://github.com/Geetha63/MS-Teams-Scripts/blob/master/Images/GrantPermissions.png)
+ 
+ ![GrantPermission](https://github.com/Geetha63/MS-Teams-Scripts/blob/master/Images/GrantPermissions2.png)
+ 
+ **Click Accept**
+
+ If you have provided the correct credentials it will give success status `admin_consent = True`
+ 
+ Now press Y to proceed further in the script
+       
+ # Output
+ 
+ Script will export the output.csv file which contains a list of deleted Teams along with owners, also it will send an email to Teams owner behalf of mail sender
+ 
+ ##### Example
+ 
+ |DeletedTeam|TeamsOwner        |
+ |-----------|------------------|
+ |HR         |fannyd@contoso.com|
+ |Accounts   |danas@contoso.com |


### PR DESCRIPTION
Adding 5 scripts
1.Add App to Teams
Script is to add TeamsApp to Teams by providing the parameters TeamId and AppName

2.Add App to Teams and Tenant
The script is to add TeamsApp to Teams or tenant by providing the parameters OwnerPrincipalName, AppName and selecting the input

3.Create New-CsTeamsMessagingPolicy
The New-CsTeamsMessagingPolicy script enables administrators to control user TeamsMessagingPolicy, determines whether a user is allowed to chat. Set this to TRUE to allow a user to chat across the private chat. Set this to FALSE to prohibit private chat

4.CreateTeamsalongwithAPPs
Create MicrosoftTeams along with APP for your tenant

5.DeleteTeamsWhereTeamMembersdontHaveGivenJobtitles
This script checks each Team member job title, if at least one job title does not match to given job titles, the script will delete those Teams. It will generate the ouput.csv file in the current folder and sent an email to deleted Team owners

This is a Graph API script, to execute the script user needs to create an Azure App and provide the necessary permissions